### PR TITLE
2024 rdss update 2024/06/21

### DIFF
--- a/OpenHouse/base_templates/common/navtop.html
+++ b/OpenHouse/base_templates/common/navtop.html
@@ -65,7 +65,7 @@
             </a>
         {% endif %}
         {% if nav_configs.show_rdss %}
-            <a class="{{ menu_ui.rdss }} item hidden-on-mobile" href="{% url 'rdss_company_index' %}">
+            <a class="{{ menu_ui.rdss }} item hidden-on-mobile" id="navtop_rdss_btn" href="{% url 'rdss_company_index' %}">
                 秋季招募
             </a>
         {% endif %}
@@ -93,7 +93,7 @@
             </div>
         {% endif %}
         {% if nav_configs.show_rdss %}
-            <div class="ui simple dropdown item hidden-on-mobile" id="rdss_navtop_dropdown">
+            <div class="ui simple dropdown item hidden-on-mobile" id="rdss_navtop_dropdown" style="font-size: 13pt;">
                 秋季招募
                 <i class="dropdown inverted icon"></i>
                 <div class="menu">

--- a/OpenHouse/careermentor/models.py
+++ b/OpenHouse/careermentor/models.py
@@ -71,7 +71,7 @@ class Signup(models.Model):
     email = models.EmailField(u'Email', max_length=64)
     time_available = models.CharField(u'場次時段內可以的時間(Available Time)', max_length=100, default='', blank=True)
     meal_category = models.CharField(u'葷素(Meal Category)',max_length=20, default='無',choices=MEAL_CATEGORY)
-    question = models.CharField(u'諮詢的內容(Enquiry)', max_length=100, default='', blank=True)
+    question = models.CharField(u'諮詢的內容(Enquiry)', max_length=100, default='')
     remark = models.CharField(u'備註(Remark)', max_length=100, default='', blank=True)
     cv_en = models.FileField(u'CV upload', upload_to='career_mentor', blank=True, null=True,
                              help_text="Optional, Better to have")

--- a/OpenHouse/company/admin.py
+++ b/OpenHouse/company/admin.py
@@ -315,7 +315,7 @@ class UserAdmin(BaseUserAdmin):
          ),
          ("收據資訊", {
             'classes': ('wide',),
-            'fields': ('receipt_title', 'receipt_postal_code', 'receipt_postal_address',
+            'fields': ('receipt_title', 'receipt_code', 'receipt_postal_code', 'receipt_postal_address',
                        'receipt_contact_name', 'receipt_contact_email', 'receipt_contact_phone')
         }
          ),
@@ -357,7 +357,7 @@ class UserAdmin(BaseUserAdmin):
          ),
          ("收據資訊", {
             'classes': ('wide',),
-            'fields': ('receipt_title', 'receipt_postal_code', 'receipt_postal_address',
+            'fields': ('receipt_title', 'receipt_code', 'receipt_postal_code', 'receipt_postal_address',
                        'receipt_contact_name', 'receipt_contact_email', 'receipt_contact_phone')
         }
          ),

--- a/OpenHouse/company/export.py
+++ b/OpenHouse/company/export.py
@@ -31,7 +31,7 @@ def Export_Company(request):
                       'postal_code', 'address', 'website',
                       'hr_name', 'hr_phone', 'hr_mobile', 'hr_email',
                       'hr2_name', 'hr2_phone', 'hr2_mobile', 'hr2_email', 'hr_ps',
-                      'brief', 'recruit_info', 'receipt_title', 'receipt_postal_code',
+                      'brief', 'recruit_info', 'receipt_title', 'receipt_code', 'receipt_postal_code',
                       'receipt_postal_address', 'receipt_contact_name', 'receipt_contact_phone',
                       'total_jobs_types', 'total_jobs',
                       'foreign_job_types', 'foreign_jobs', 'liberal_job_types', 'liberal_jobs']

--- a/OpenHouse/company/models.py
+++ b/OpenHouse/company/models.py
@@ -87,9 +87,10 @@ class Company(AbstractBaseUser):
     gloria_startup = models.BooleanField(u'國際產學聯盟總中心_國際新創會員', default=False)
 
     # receipt information
-    receipt_title = models.CharField(u'公司收據抬頭', max_length=80, default="", help_text="ex. 12345678國立陽明交通大學")
+    receipt_title = models.CharField(u'公司收據抬頭', max_length=80, default="", help_text="ex. 國立陽明交通大學")
+    receipt_code = models.CharField(u'公司收據統編', max_length=8, default="", help_text="ex. 12345678")
     receipt_postal_code = models.CharField(u'收據寄送郵遞區號(3+3)',help_text='ex:300123', max_length=6, default="",  validators=[validate_all_num])
-    receipt_postal_address = models.CharField(u'收據寄送地址', max_length=128, default="", help_text="另註公司名尤佳")
+    receipt_postal_address = models.CharField(u'收據寄送地址', max_length=128, default="", help_text="")
     receipt_contact_name =  models.CharField(u'收據聯絡人姓名', max_length=10, default="")
     receipt_contact_email =  models.CharField(u'收據聯絡人Email', max_length=64, default="", validators=[validate_email])
     receipt_contact_phone = models.CharField(u'收據聯絡人公司電話', max_length=32, default="", help_text='格式: 區碼-號碼#分機')

--- a/OpenHouse/company/templates/company_create_form.html
+++ b/OpenHouse/company/templates/company_create_form.html
@@ -171,11 +171,15 @@
             {{ form.receipt_title }}
         </div>
         <div class="required field">
+            <label>{{ form.receipt_code.label_tag }}</label>
+            {{ form.receipt_code }}
+        </div>
+        <div class="required field">
             <label>{{ form.receipt_postal_code.label_tag }} {{ form.receipt_postal_code.help_text }}</label>
             {{ form.receipt_postal_code }}
         </div>
         <div class="required field">
-            <label>{{ form.receipt_postal_address.label_tag }} ({{ form.receipt_postal_address.help_text }})</label>
+            <label>{{ form.receipt_postal_address.label_tag }} {{ form.receipt_postal_address.help_text }}</label>
             {{ form.receipt_postal_address }}
         </div>
         <div class="required field">

--- a/OpenHouse/company/templates/company_edit_form.html
+++ b/OpenHouse/company/templates/company_edit_form.html
@@ -123,6 +123,21 @@
                     alert('開放外籍生選擇職缺建議一併填寫英文職缺名稱、內容')
                 }
             });
+            $('.ui.form')
+            .form({
+                onSuccess: function(event, fields) {
+                    var receiptCode = $('input[name="receipt_code"]').val();
+                    var isValid = /^[0-9]{8}$/.test(receiptCode);
+                    if (!isValid) {
+                        alert('請輸入8位數字的公司收據統編');
+                        $('input[name="receipt_code"]').css({
+                            'border-color': 'red',
+                            'background-color': 'rgba(255, 0, 0, 0.1)'
+                        });
+                        event.preventDefault();
+                    }
+                }
+            }) ;
         });
  
     </script>
@@ -228,11 +243,15 @@
                         {{ form.receipt_title }}
                     </div>
                     <div class="required field">
+                        <label>{{ form.receipt_code.label_tag }} {{ form.receipt_code.help_text }}</label>
+                        {{ form.receipt_code }}
+                    </div>
+                    <div class="required field">
                         <label>{{ form.receipt_postal_code.label_tag }} {{ form.receipt_postal_code.help_text }}</label>
                         {{ form.receipt_postal_code }}
                     </div>
                     <div class="required field">
-                        <label>{{ form.receipt_postal_address.label_tag }} ({{ form.receipt_postal_address.help_text }})</label>
+                        <label>{{ form.receipt_postal_address.label_tag }} {{ form.receipt_postal_address.help_text }}</label>
                         {{ form.receipt_postal_address }}
                     </div>
                     <div class="required field">

--- a/OpenHouse/company/templates/company_index.html
+++ b/OpenHouse/company/templates/company_index.html
@@ -14,7 +14,7 @@
         <img id="logo_img" src={% static 'images/oh_logo_2023_white.jpeg' %} alt="校園徵才">
         <div class="ui equal width centered grid" id="file_area">
             <!--Recruit file area -->
-            <div class="ten wide column">
+            <!-- <div class="ten wide column">
                 <h2 style="text-align: center;">春季徵才</h2>
 
                 <a class="ui blue button" style="text-align: center; margin-bottom:2em"
@@ -33,11 +33,11 @@
                         </tbody>
                     </table>
                 </div>
-            </div>
+            </div> -->
 
             <!-- Autumn recruit-->
             <!-- hide for 2024 recruit -->
-            <!-- <div class="column">
+            <div class="ten wide column">
                 <h2 style="text-align: center;">秋季招募</h2>
                 <a class="ui blue button" style="text-align: center; margin-bottom:2em"
                    href={% url 'rdss_company_index' %}>前往秋季招募活動面版</a>
@@ -54,8 +54,7 @@
                         </tbody>
                     </table>
                 </div>
-            </div> -->
-
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/OpenHouse/company/templates/company_info.html
+++ b/OpenHouse/company/templates/company_info.html
@@ -29,6 +29,10 @@
                     <td>{{ company_info.receipt_title }}</td>
                 </tr>
                 <tr>
+                    <td>公司收據統編</td>
+                    <td>{{ company_info.receipt_code }}</td>
+                </tr>
+                <tr>
                     <td>收據寄送郵遞區號(3+3)</td>
                     <td>{{ company_info.receipt_postal_code }}</td>
                 </tr>
@@ -91,11 +95,6 @@
                     <td>統編</td>
                     <td>{{ company_info.cid }}</td>
                 </tr>
-                <tr>
-                    <td>公司收據抬頭</td>
-                    <td>{{ company_info.receipt_title }}</td>
-                </tr>
-
                 <tr>
                     <td>營業項目</td>
                     <td>{{ company_info.business_project }}</td>

--- a/OpenHouse/rdss/admin.py
+++ b/OpenHouse/rdss/admin.py
@@ -76,7 +76,7 @@ class SponsorItemsAdmin(admin.ModelAdmin):
 
 @admin.register(models.Signup)
 class SignupAdmin(admin.ModelAdmin):
-    list_display = ('cid', 'company_name', 'seminar', 'jobfair', 'jobfair_online', 'career_tutor', 'visit', 'lecture', 'payment')
+    list_display = ('cid', 'company_name', 'seminar', 'jobfair', 'career_tutor', 'visit', 'lecture', 'payment')
     inlines = (SponsorshipInline,)
     search_fields = ('cid',)
 
@@ -288,15 +288,15 @@ class JobfairContentAdmin(admin.ModelAdmin):
         return False
 
 
-@admin.register(models.RdssOnlineJobfairInfo)
-class OnlineJobfairContentAdmin(admin.ModelAdmin):
-    list_display = ('title',)
+# @admin.register(models.RdssOnlineJobfairInfo)
+# class OnlineJobfairContentAdmin(admin.ModelAdmin):
+#     list_display = ('title',)
 
-    def has_add_permission(self, request):
-        count = rdss.models.RdssOnlineJobfairInfo.objects.all().count()
-        if count == 0:
-            return True
-        return False
+#     def has_add_permission(self, request):
+#         count = rdss.models.RdssOnlineJobfairInfo.objects.all().count()
+#         if count == 0:
+#             return True
+#         return False
 
 
 @admin.register(models.Sponsorship)
@@ -308,4 +308,4 @@ class SponsorshipAdmin(admin.ModelAdmin):
 # Register your models here.
 # admin.site.register(models.Sponsorship)
 admin.site.register(models.JobfairSlot)
-admin.site.register(models.OnlineJobfairSlot)
+# admin.site.register(models.OnlineJobfairSlot)

--- a/OpenHouse/rdss/admin.py
+++ b/OpenHouse/rdss/admin.py
@@ -45,6 +45,18 @@ class RedeemAdmin(admin.ModelAdmin):
 class ECESeminarAdmin(admin.ModelAdmin):
     list_display = ('seminar_name','ece_member_discount',)
 
+@admin.register(models.CompanyCatogories)
+class CompanyCategoriesAdmin(admin.ModelAdmin):
+    list_display = ('name', 'discount')
+
+@admin.register(models.ZoneCatogories)
+class ZoneCatogoriesAdmin(admin.ModelAdmin):
+    list_display = ('name', 'discount', 'display_categories')
+    list_filter = ('category', )
+    def display_categories(self, obj):
+        return ', '.join(category.name for category in obj.category.all())
+
+    display_categories.short_description = 'Categories'
 
 @admin.register(models.SeminarSlot)
 class SeminarSlotAdmin(admin.ModelAdmin):

--- a/OpenHouse/rdss/export.py
+++ b/OpenHouse/rdss/export.py
@@ -274,6 +274,7 @@ def ExportAll(request):
         {'fieldname': 'shortname', 'title': '公司簡稱'},
         {'fieldname': 'english_name', 'title': '公司英文名稱'},
         {'fieldname': 'receipt_title', 'title': '公司收據抬頭'},
+        {'fieldname': 'receipt_code', 'title': '公司收據統編'},
         {'fieldname': 'receipt_postal_code', 'title': '收據寄送郵遞區號'},
         {'fieldname': 'receipt_postal_address', 'title': '收據寄送地址'},
         {'fieldname': 'receipt_contact_name', 'title': '收據聯絡人姓名'},

--- a/OpenHouse/rdss/forms.py
+++ b/OpenHouse/rdss/forms.py
@@ -14,6 +14,10 @@ class SignupCreationForm(forms.ModelForm):
         self.fields['seminar_ece'].widget.attrs.update({
             'class': 'ui dropdown',
         })
+        self.fields['jobfair'].widget.attrs.update({
+            'max' : '6',
+            'min' : '0'
+        })
 
     class Meta:
         model = rdss.models.Signup
@@ -22,33 +26,6 @@ class SignupCreationForm(forms.ModelForm):
 
     def save(self, commit=True):
         record = super(SignupCreationForm, self).save(commit=False)
-        if commit:
-            record.save()
-        return record
-
-
-class SignupEditForm(forms.ModelForm):
-
-    def __init__(self, *args, **kwargs):
-        super(SignupCreationForm, self).__init__(*args, **kwargs)
-        self.fields['seminar'].widget.attrs.update({
-            'class': 'ui dropdown',
-        })
-
-    class Meta:
-        model = rdss.models.Signup
-        fields = '__all__'
-        exclude = ['payment', 'receipt_no', 'ps']
-
-    # def clean_cid(self):
-    #       raise forms.ValidationError(
-    #               self.error_messages['cid_error'],
-    #               code='cid_error'
-    #               )
-    #       return cid
-
-    def save(self, commit=True):
-        record = super(SignupEditForm, self).save(commit=False)
         if commit:
             record.save()
         return record

--- a/OpenHouse/rdss/forms.py
+++ b/OpenHouse/rdss/forms.py
@@ -84,32 +84,29 @@ class JobfairInfoCreationForm(forms.ModelForm):
     class Meta:
         model = rdss.models.JobfairInfo
         fields = '__all__'
-        exclude = ['cid', 'ps']
+        exclude = ['company']
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, max_num=None, **kwargs):
         super(JobfairInfoCreationForm, self).__init__(*args, **kwargs)
+        self.fields['lunch_box'].widget.attrs.update({
+            'max' : max_num*3,
+            'min' : '0'
+        })
+        self.fields['parking_tickets'].widget.attrs.update({
+            'max' : max_num*2,
+            'min' : '0'
+        })
         self.fields['contact_mobile'].widget.attrs.update({
             'placeholder': '格式：0912-345678',
         })
         self.fields['meat_lunchbox'].widget.attrs.update({
-            'placeholder': '若不索取，填0即可',
+            'max' : max_num*3,
+            'min' : '0'
         })
         self.fields['vege_lunchbox'].widget.attrs.update({
-            'placeholder': '若不索取，填0即可',
+            'max' : max_num*3,
+            'min' : '0'
         })      
-
-    # def clean_cid(self):
-    #       raise forms.ValidationError(
-    #               self.error_messages['cid_error'],
-    #               code='cid_error'
-    #               )
-    #       return cid
-
-    def save(self, commit=True):
-        record = super(JobfairInfoCreationForm, self).save(commit=False)
-        if commit:
-            record.save()
-        return record
 
 
 class EmailPostForm(forms.Form):

--- a/OpenHouse/rdss/models.py
+++ b/OpenHouse/rdss/models.py
@@ -47,6 +47,32 @@ CATEGORYS = (
     (u'其他', u'其他'),
 )
 
+class CompanyCatogories(models.Model):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(u'公司類別名稱', max_length=50)
+    discount = models.BooleanField(u'公家機關優惠', default=False)
+
+    def __str__(self):
+        return u'{}'.format(self.name)
+
+    class Meta:
+        managed = True
+        verbose_name = u'公司類別設定'
+        verbose_name_plural = u'公司類別設定'
+
+class ZoneCatogories(models.Model):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(u'專區名稱', max_length=20)
+    discount = models.IntegerField(u'專區優惠', default=0)
+    category = models.ManyToManyField('CompanyCatogories', verbose_name=u'公司類別', blank=True)
+
+    def __str__(self):
+        return u'{}'.format(self.name)
+
+    class Meta:
+        managed = True
+        verbose_name = u'專區設定'
+        verbose_name_plural = u'專區設定'
 
 class RdssConfigs(models.Model):
     id = models.AutoField(primary_key=True)
@@ -131,6 +157,7 @@ class Signup(models.Model):
     )
     id = models.AutoField(primary_key=True)
     cid = models.CharField(u'公司統一編號', unique=True, max_length=8, null=False)
+    zone = models.ForeignKey('ZoneCatogories', verbose_name=u'專區類別', on_delete=models.CASCADE, null=True)
     seminar = models.CharField(u'說明會場次', max_length=15,
                                choices=SEMINAR_CHOICES, default='none', blank=True)
     jobfair = models.IntegerField(u'徵才展示會攤位數量', default=0, validators=[ MinValueValidator(0)])

--- a/OpenHouse/rdss/models.py
+++ b/OpenHouse/rdss/models.py
@@ -102,6 +102,7 @@ class RdssConfigs(models.Model):
         ('bento', u'便當(葷素)')
     )
     jobfair_food = models.CharField(u'就業博覽會餐點', max_length=10, choices=JOBFAIR_FOOD_CHOICES, default='餐盒(蛋奶素)')
+    jobfair_food_info = RichTextField(u'餐點注意事項', max_length=128, blank=True, null=True)
 
     class Meta:
         managed = True
@@ -427,16 +428,10 @@ class JobfairInfo(models.Model):
                                       validators=[validate_mobile])
     contact_email = models.EmailField(u'聯絡人Email', max_length=254)
     
-    PARKING_CHOICES = (
-        ('ticket', u'當日索取紙本停車抵用券'),
-        ('register', u'企業事先登記A車車牌號碼')
-    )
-    parking_type = models.CharField(u'停車方式', max_length=20, choices=PARKING_CHOICES, null=True, default='ticket')
-    
-    LUNCH_BOX_CHOICES = [(i, str(i)) for i in range(4)]
-    lunch_box = models.SmallIntegerField(u'餐盒數量', choices=LUNCH_BOX_CHOICES, default=0, help_text="餐盒預設為蛋奶素", blank=True, null=True)
-    meat_lunchbox = models.SmallIntegerField(u'葷食餐點數量', choices=LUNCH_BOX_CHOICES, default=0, blank=True, null=True)
-    vege_lunchbox = models.SmallIntegerField(u'素食餐點', choices=LUNCH_BOX_CHOICES, default=0, blank=True, null=True)
+    parking_tickets = models.IntegerField(u'停車證數量', default=0, blank=True, null=True)
+    lunch_box = models.SmallIntegerField(u'餐盒數量', default=0, help_text="餐盒預設為蛋奶素", blank=True, null=True)
+    meat_lunchbox = models.SmallIntegerField(u'葷食餐點數量', default=0, blank=True, null=True)
+    vege_lunchbox = models.SmallIntegerField(u'素食餐點', default=0, blank=True, null=True)
 
     power_req = models.CharField(u'用電需求', max_length=256,
                                  help_text="請填寫當天會使用的用電設備")

--- a/OpenHouse/rdss/models.py
+++ b/OpenHouse/rdss/models.py
@@ -112,11 +112,13 @@ class RdssConfigs(models.Model):
     jobfair_start = models.TimeField(u'就博會開始時間')
     jobfair_end = models.TimeField(u'就博會結束時間')
     jobfair_booth_fee = models.IntegerField(u'就博會攤位費用(每攤)', default=0)
-    jobfair_online_start = models.DateField(u'線上就博會開始日期', default=datetime.date.today)
-    jobfair_online_end = models.DateField(u'線上就博會結束日期', default=datetime.date.today)
-    jobfair_online_fee = models.IntegerField(u'線上就博會費用', default=0)
-    jobfair_drawing_start = models.DateField(u'系統宣傳抽獎開始日期', default=datetime.date.today)
-    jobfair_drawing_end = models.DateField(u'系統宣傳抽獎結束日期', default=datetime.date.today)
+    
+    # 線上就博會相關
+    # jobfair_online_start = models.DateField(u'線上就博會開始日期', default=datetime.date.today)
+    # jobfair_online_end = models.DateField(u'線上就博會結束日期', default=datetime.date.today)
+    # jobfair_online_fee = models.IntegerField(u'線上就博會費用', default=0)
+    # jobfair_drawing_start = models.DateField(u'系統宣傳抽獎開始日期', default=datetime.date.today)
+    # jobfair_drawing_end = models.DateField(u'系統宣傳抽獎結束日期', default=datetime.date.today)
 
     seminar_btn_start = models.DateField(u'說明會按鈕開啟日期', null=True)
     seminar_btn_end = models.DateField(u'說明會按鈕關閉日期', null=True)

--- a/OpenHouse/rdss/templates/company/jobfair_info_form.html
+++ b/OpenHouse/rdss/templates/company/jobfair_info_form.html
@@ -4,29 +4,6 @@
 {% block 'custom_head' %}
     <title>就博會資訊 | OpenHouse 企業校園徵才</title>
     <link href={% static "css/rdss/info.css" %} rel="stylesheet">
-    <script>
-        function init() {
-            var selectedValue = $('#id_parking_type').val();
-            if (selectedValue === 'register') {
-                    $('#registerField').show();
-            }
-        }
-
-         $(document).ready(function () {
-            init();
-
-            $('#id_parking_type').change(function () {
-                $('#registerField').hide();
-        
-                var selectedValue = $(this).val();
-                console.log(selectedValue);
-        
-                if (selectedValue === 'register') {
-                    $('#registerField').show();
-                }
-            });
-        });
-    </script>
 {% endblock %}
 
 {% block 'content' %}
@@ -89,29 +66,32 @@
                 {{ form.contact_email.errors }}
             </div>
         </div>
-        <h3 class="ui dividing header">餐點數量</h3>
-        <p>每攤位免費提供<span style="color:red;">最多 3 人份午餐</span>。若超過免費數量，將收取超出的餐點費用。</p>
-        <div class="fields">
+
+        <div class="two fields">
             {% if food_type == 'bento' %}
-                <div class="six wide field required">
-                    <label>{{ form.meat_lunchbox.label }} (若不索取，填0即可)</label>
-                    {{ form.meat_lunchbox }}
-                    {{ form.meat_lunchbox.errors }}
-                </div>
-                <div class="six wide field required">
-                    <label>{{ form.vege_lunchbox.label }} (若不索取，填0即可)</label>
-                    {{ form.vege_lunchbox }}
-                    {{ form.vege_lunchbox.errors }}
-                </div>
+            <div class="field">
+                <label>{{ form.meat_lunchbox.label }}</label>
+                {{ form.meat_lunchbox }}
+            </div>
+            <div class="field">
+                <label>{{ form.vege_lunchbox.label }}</label>
+                {{ form.vege_lunchbox }}
+            </div>
             {% else %}
-                <div class="six wide field required">
-                    <label>{{ form.lunch_box.label }}</label>
-                    {{ form.lunch_box }}
-                    {{ form.lunch_box.help_text }}
-                    {{ form.lunch_box.errors }}
-                </div>
+            <div class="field">
+                <label>{{ form.lunch_box.label }}</label>
+                {{ form.lunch_box }}
+                {{ form.lunch_box.help_text }}
+            </div>
             {% endif %}
+            <div class="field">
+                <label>餐點注意事項</label>
+                {{ food_info | safe }}
+            </div>
+            <br/>
         </div>
+        <p>每攤位免費提供至多3份午餐。<span style="color:red;">貴公司至多 {{ booth_quantity }} 份。</span></p>
+
         <div class="fields">
             <div class="fourteen wide field required">
                 <label>{{ form.power_req.label }}</label>
@@ -121,42 +101,25 @@
             </div>
 
         </div>
-        {# <div class="field">  #}
-        {#     <label>{{ form.ps.label }}</label>  #}
-        {#     {{ form.ps }}  #}
-        {#     {{ form.ps.errors }}  #}
-        {# </div>  #}
 
         <h3 class="ui dividing header">入校之汽車車號提供或需要(紙本)汽車停車抵用券</h3>
-        <p>說明(1)：參加2023/3/9(六)就業博覽會之企業，至多提供1部汽車入校停車費抵免；企業可選擇「事先登記車牌號碼」與「當日索取紙本停車抵用券」兩種並行。</p>
+        <p>說明(1)：參加2024/(   )就業博覽會之企業，每攤提供2部汽車入校停車費抵免；企業可選擇需要索取多少紙本停車抵用券，活動當日發放。</p>
         <ul>
+            <li>
+                <span style="color:red; background-color: yellow;">每攤至多提供2張</span>紙本停車抵用券</span>
+            </li>
             <li>
                 <span style="color:red; background-color: yellow;">當日索取紙本停車抵用券</span>: 本組當日發放紙本停車證，可免費抵用一台汽車的停車費。
             </li>
-            <li>
-                <span style="color:red; background-color: yellow;">企業事先登記A車車牌號碼</span>: 本組呈報車號給駐警隊，請駐警隊登記A車免費。活動當天A車免費進出校園一次，若開其他車則須付費。
-            </li>
         </ul>
-        <p>說明(2)：本校進出車輛自2020年1月已改用車號辨識系統，可加速企業同仁離校速度與簡化繳費流程，如選擇此項之車輛須提供完整車號(需要-連字號，例AA-1234、4321-BB)；若無法事先確認入校車輛之車牌號碼，請選擇索取紙本汽車抵用券。</p>
-        <p>說明(3)：如超過基本提供數量，須自付每部每時30元之計時停車(備註：停車費用逕向出入口收費亭繳費即可)。</p>
+        <p>說明(2)：如超過基本提供數量，須自付每部每時30元之計時停車(備註：停車費用逕向出入口收費亭繳費即可)。</p>
         <!-- <p style="color: red">★如要刪除已新增的車牌號碼，請勾選相應欄位右方的"刪除"選項</p> -->
-        <div class="field">
-            <label>停車證領取方式</label>
-            {{ form.parking_type.errors }}
-            {{ form.parking_type }}
-        </div>
-        <div class="field" id="registerField" style="display: none;">
-            {{ formset.management_form }}
-            {% for f in formset %}
-                {{ f.id }}
-                {{ f.info }}
-                <label>
-                    {{ f.license_plate_number.label }} {{ forloop.counter }} {{ f.license_plate_number.errors }}</label>
-                <div class="fields">
-                        {{ f.license_plate_number }}
-                </div>
-            {% endfor %}
-            <p style="color:red; background-color: yellow;">車輛須提供完整車號(需要-連字號，例AA-1234、4321-BB)</p>
+        <div class="two fields">
+            <div class="field">
+                <label>{{ form.parking_tickets.label }}</label>
+                {{ form.parking_tickets }}
+                <p>每攤位免費提供1張停車證。<span style="color:red;">貴公司至多 {{ booth_parking_tickets }} 張。</span></p>
+            </div>
         </div>
         <button class="ui blue button" style="float: right;" type="submit">送出</button>
     </form>

--- a/OpenHouse/rdss/templates/company/signup_form.html
+++ b/OpenHouse/rdss/templates/company/signup_form.html
@@ -25,7 +25,25 @@
         </div>
 
         <div class="ui divider"></div>
+        <div class="ui yellow inverted segment">
+            <h1 class="ui inverted header">
+                <i class="certificate icon" style="color:white"></i>
+                企業參與調查
+            </h1>
 
+            <table class="ui celled table">
+                <tr>
+                    <td>專區調查</td>
+                    <td>
+                        攤位區域分為「一般企業」、「多元企業」、「生技專區」
+                        <br/>請選擇貴公司欲參加專區
+                        {{ form.zone }}
+                    </td>
+                </tr>
+            </table>
+        </div>
+
+        <div class="ui divider"></div>
         <div class="ui violet inverted segment">
             <h1 class="ui inverted header">
                 <i class="calendar icon" style="color:white"></i>

--- a/OpenHouse/rdss/templates/company/status.html
+++ b/OpenHouse/rdss/templates/company/status.html
@@ -164,7 +164,8 @@
                 <tr>
                     <td>折扣費用</td>
                     <td>
-                        -{{ discount }} 元
+                        -{{ discount }} 元 <br/>
+                        {{ discount_text }}
                     </td>
                 </tr>
                 </tbody>

--- a/OpenHouse/recruit/export.py
+++ b/OpenHouse/recruit/export.py
@@ -157,6 +157,7 @@ def ExportAll(request):
         {'fieldname': 'shortname', 'title': '公司簡稱'},
         {'fieldname': 'english_name', 'title': '公司英文名稱'},
         {'fieldname': 'receipt_title', 'title': '公司收據抬頭'},
+        {'fieldname': 'receipt_code', 'title': '公司收據統編'},
         {'fieldname': 'receipt_postal_code', 'title': '收據寄送郵遞區號'},
         {'fieldname': 'receipt_postal_address', 'title': '收據寄送地址'},
         {'fieldname': 'receipt_contact_name', 'title': '收據聯絡人姓名'},

--- a/OpenHouse/recruit/forms.py
+++ b/OpenHouse/recruit/forms.py
@@ -111,7 +111,6 @@ class JobfairInfoForm(ModelForm):
         self.fields['contact_mobile'].widget.attrs.update({
             'placeholder': '格式：0912-345678',
         })
-        print(max_num)
         self.fields['lunch_box'].widget.attrs.update({
             'max' : max_num*3,
             'min' : '0'

--- a/OpenHouse/recruit/views.py
+++ b/OpenHouse/recruit/views.py
@@ -1412,7 +1412,8 @@ def Status(request):
     
     target_company = Company.objects.get(cid=mycid)
     
-    if target_company.receipt_title == ""  or target_company.receipt_postal_code == ""  \
+    if target_company.receipt_title == "" or target_company.receipt_code == "" \
+        or target_company.receipt_postal_code == ""  \
         or target_company.receipt_postal_address == ""  or target_company.receipt_contact_name == ""  \
         or target_company.receipt_contact_phone == "" :
         fill_receipt = False


### PR DESCRIPTION
餐盒連動攤位功能 （p.s.葷素便當數量限制沒有做好)
停車券新增車號功能刪除
職場導師諮詢內容變更為必填

## 專區功能許願＆連動

- 要先新增公司類別 勾選公家機關優惠的話在算錢的時候會直接免費
- 到專區設定設定專區 可以選要哪些公司類別
- 設定秋招活動設定
- 上傳活動企劃書 類別企劃書會跟廠商入口的活動企劃書連動
- 專區會有優惠減免連動 以在專區設定中的優惠減免為準
- 公家單位優惠以 公司類別設定 有勾選公家單位的類別為準

## 總廠商列表收據資訊更動

- 收據資訊 → 公司收據抬頭 → ex. 12345678國立陽明交通大學 (改成國立陽明交通大學)
- & 收據資訊 → 公司收據統編→ ex. 12345678
- 收據資訊 → 收據寄送地址 → 另註公司名尤佳 (刪除此備註)

