### PR TITLE
[2024 rdss] Separate category from company model 

### DIFF
--- a/OpenHouse/company/models.py
+++ b/OpenHouse/company/models.py
@@ -20,6 +20,18 @@ def validate_mobile(string):
 def validate_phone(string):
     RegexValidator(regex='^\d+-\d+(#\d+)?$', message='電話/傳真格式為：區碼-號碼#分機')(string)
 
+class CompanyCatogories(models.Model):
+    id = models.AutoField(primary_key=True)
+    name = models.CharField(u'公司類別名稱', max_length=50, unique=True)
+    discount = models.BooleanField(u'公家機關優惠', default=False, help_text='勾選後該類別參展免費')
+
+    def __str__(self):
+        return u'{}'.format(self.name)
+
+    class Meta:
+        managed = True
+        verbose_name = u'公司類別設定'
+        verbose_name_plural = u'公司類別設定'
 
 class Company(AbstractBaseUser):
     CATEGORYS = (
@@ -49,7 +61,9 @@ class Company(AbstractBaseUser):
     name = models.CharField(u'公司名稱', max_length=64)
     english_name = models.CharField(u'公司英文完整名稱', max_length=100, default='None')
     shortname = models.CharField(u'公司簡稱', max_length=20)
-    category = models.CharField(u'類別', max_length=37, choices=CATEGORYS, help_text='公司主要事業類別')
+    # category = models.CharField(u'類別', max_length=37, choices=CATEGORYS, help_text='公司主要事業類別')
+    # When category is deleted, set company's category to null
+    category = models.ForeignKey('CompanyCatogories', to_field='name', verbose_name=u'公司類別', on_delete=models.SET_NULL, null=True)
     phone = models.CharField(u'公司電話', max_length=32, help_text='格式: 區碼-號碼#分機')
     postal_code = models.CharField(u'郵遞區號(3+3)', max_length=6,help_text='ex:300123', validators=[validate_all_num])
     address = models.CharField(u'公司地址', max_length=128)

--- a/OpenHouse/rdss/views.py
+++ b/OpenHouse/rdss/views.py
@@ -1125,8 +1125,7 @@ def QueryPoints(request):
 def ListJobs(request):
     # semantic ui control
     sidebar_ui = {'list_jobs': "active"}
-
-    categories = [category[0] for category in Company.CATEGORYS]
+    categories = [category.name for category in company.models.CompanyCatogories.objects.all()]
     companies = []
     category_filtered = request.GET.get('categories') if request.GET.get('categories') else None
     if category_filtered and category_filtered != 'all':

--- a/OpenHouse/recruit/views.py
+++ b/OpenHouse/recruit/views.py
@@ -23,12 +23,12 @@ import datetime
 import json
 import logging
 from ipware.ip import get_client_ip
-from company.models import Company
 from datetime import timedelta
 import recruit.models
 from urllib.parse import urlparse, parse_qs
 import re
 import recruit.models
+import company.models
 from .data_import import ImportStudentCardID
 from django.db.utils import IntegrityError
 
@@ -1447,7 +1447,8 @@ def list_jobs(request):
     # semantic ui control
     sidebar_ui = {'list_jobs': "active"}
 
-    categories = [category[0] for category in Company.CATEGORYS]
+    categories = [category.name for category in company.models.CompanyCatogories.objects.all()]
+    # categories = [category[0] for category in Company.CATEGORYS]
     companies = []
     category_filtered = request.GET.get('categories') if request.GET.get('categories') else None
     if category_filtered and category_filtered != 'all':


### PR DESCRIPTION
## Backgroud
To meet the demand for dynamic adjustment of company categories, separate category charfield from company model. New category model will be a foreign key of company model, and set to `on_delete=set_null`  
Therefore, admin can add new categories without edition of code.  
A大類 - 農、林、漁、牧業、B大類 - 礦業及土石採取業、C大類 - 製造業(刪除「傳統」2字)、E大類 - 用水供應及污染整治業、F大類 - 營造業、M大類 - 專業、科學及技術服務業、N大類 - 支援服務業、O大類 - 公共行政及國防；強制性社會安全、P大類 - 教育服務業、S大類 - 其他服務業

## TODO
Connect categories in rdss/recruit